### PR TITLE
Use Object.defineProperty to extend prototypes

### DIFF
--- a/src/extensions/Array.js
+++ b/src/extensions/Array.js
@@ -2,20 +2,33 @@
  * Faster than .forEach
  * @param {(function())} fn The function to call
  */
-Array.prototype.each = function (fn) {
+function arrayEach(fn) {
 	const l = this.length
 
-	for(let i = 0; i < l; i++) {
+	for (let i = 0; i < l; i++) {
 		const e = this[i]
 
 		if (e) {
-			fn(e,i)
+			fn(e, i)
 		}
 	}
 }
 
+Object.defineProperty(Array.prototype, "each", {
+	value: arrayEach,
+	enumerable: false,
+});
+
 /**
  * Give NodeList some Array functions
  */
-NodeList.prototype.each = Array.prototype.each
-NodeList.prototype.filter = Array.prototype.filter
+Object.defineProperties(NodeList.prototype, {
+	each: {
+		value: Array.prototype.each,
+		enumerable: false,
+	},
+	filter: {
+		value: Array.prototype.filter,
+		enumerable: false
+	}
+});


### PR DESCRIPTION
Extending the Array prototype by assignment causes unexpected behavior when iterating via the `in` operator.

[CodePen with example](https://codepen.io/majgaard/pen/XWyvZzX?editors=1111)

Instead, `Object.defineProperty` with `enumerable: false` should be used.